### PR TITLE
Add save() method

### DIFF
--- a/src/Config/Output.php
+++ b/src/Config/Output.php
@@ -186,6 +186,18 @@ trait Output
 
         return $this->fpassthru();
     }
+    
+    /**
+     * Writes the CSV data to the specified file path on the local file system
+     * 
+     * @param string $path The local path where the file will be saved
+     * 
+     * @return int|false The number of bytes written to the file or false on failure
+     */
+    public function save($path)
+    {
+        file_put_contents($path, $this->__toString());   
+    }
 
     /**
      * Outputs all data from the CSV


### PR DESCRIPTION
## Introduction

Currently I can't see any method for saving the csv data to the local file system. The current solution is to use file_get_contents($csv->__toString()) which works fine, but looks ugly.

## Proposal 

### Describe the new/upated/fixed feature

This PR adds a simple save($path) method to the CSV object allowing the developer to quickly and easily save the CSV data to a local file system. This is appropriate when the developer wants to produce CSV data that is not being sent via an HTTP request.

### Backward Incompatible Changes

Nope.

### Targeted release version

8.1.3

### PR Impact

Adds an additional save() method to a CSV file object.

## Open issues

Add save() method for writing the CSV data to the local file system